### PR TITLE
[breaking] chore: update soundworks version to v4.0.0-alpha.20

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2019 IRCAM – Centre Pompidou (France, Paris)
+Copyright (c) 2014-present IRCAM – Centre Pompidou (France, Paris)
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# `@soundworks/max`
+# soundworks | max
 
-> Utility to monitor and control soundworks' shared states within Max
+Utility to monitor and control soundworks' shared states within [Max](https://cycling74.com/products/max-features).
 
-This repository is about a [Max](https://cycling74.com/products/max-features) package tested on Mac.  
-Windows version should work but is untested.
+_Note that this repository has been tested on Mac only, Windows version should work but is untested._
 
 ## Table of Contents
 
@@ -48,47 +47,44 @@ and follow the instructions.
 
 ### Install
 
-@TODO rewrite  
 ```sh
-npm install --save @soundworks/soundworks-max
+npm install --save @soundworks/max
 ```
-
 
 ### Usage
 
-@TODO rewrite  
 In the `src/server/index.js` of your soundworks application:
 
 1. Import the `soundworksMax` object
 
 ```js
 import { Server } from '@soundworks/core/server.js';
-// import the `configureMaxClient` function from the @soundworks/max package
+// 1. Import the `configureMaxClient` function from the @soundworks/max package
 import { configureMaxClient } from '@soundworks/max';
-
 import { loadConfig } from '../utils/load-config.js';
 
-// extends with config object to configure max client
+// 2. Configure max client
 const config = loadConfig(process.env.ENV, import.meta.url);
 configureMaxClient(config);
 
 const server = new Server(config);
 ```
 
-## Next Steps
-
-- `[soundworks.shared-state.observe]`
-- `[soundworks.sync]`
-
 ## Caveats
 
 Each `soundworks.shared-state` object creates a new soundworks client, which is 
 known suboptimal, but improves user friendliness.
 
-One of our unit test use 25 instances, which work on all systems without problems.  
+One of our unit test use 25 instances, which work on all systems without issues.  
 This test has been run with 100 objects successfully on ARM, but not on Intel.  
 
 ## Development notes
+
+### Link Max package into `Documents/Max 8/Packages`
+
+```sh
+ln -s .path/to/soundworks-max/max/soundworks ~/Documents/Max\ 8/Packages
+```
 
 ### Running the test suite
 
@@ -112,7 +108,7 @@ VERBOSE=1 npm test -- tests/the-test/index.spec.js
 
 ### How to open patcher ?
 
-CMD + OPTION + M puis CMD + E puis appuyer sur le bouton
+`CMD + OPTION + M` then `CMD + E` then click on the button
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,16 @@ Notes:
 - [Max](#max)
   * [Install](#install)
   * [Usage](#usage)
-- [Running the example](#running-the-example)
+  * [Running the example](#running-the-example)
 - [Javascript](#javascript)
   * [Install](#install-1)
   * [Usage](#usage-1)
-- [Next Steps](#next-steps)
 - [Caveats](#caveats)
-- [Running the test suite](#running-the-test-suite)
-- [Acknowledgements](#acknowledgements)
+- [Development notes](#development-notes)
+  * [Link Max package into `Documents/Max 8/Packages`](#link-max-package-into-documentsmax-8packages)
+  * [Running the test suite](#running-the-test-suite)
+  * [How to open patcher?](#how-to-open-patcher)
+- [Credits](#credits)
 - [License](#license)
 
 <!-- tocstop -->
@@ -38,9 +40,9 @@ Notes:
 See the overview patch for more informations  
 cf. `~/Documents/Max 8/Packages/soundworks/extras/soundworks.maxpat`
 
-## Running the example
+### Running the example
 
-1. From the overview click `soundworks.shared-state`  
+1. In the "overview" menu click `soundworks.shared-state`  
 2. Start the soundworks server by opening the `soundworks.example.server`   
 and follow the instructions.
 
@@ -107,7 +109,7 @@ For verbose output
 VERBOSE=1 npm test -- tests/the-test/index.spec.js
 ```
 
-### How to open patcher ?
+### How to open patcher?
 
 `CMD + OPTION + M` then `CMD + E` then click on the button
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Utility to monitor and control soundworks' shared states within [Max](https://cycling74.com/products/max-features).
 
-_Note that this repository has been tested on Mac only, Windows version should work but is untested._
+Notes: 
+- This repository has been tested on Mac only, Windows version should work but is untested.
 
 ## Table of Contents
 

--- a/max/soundworks/examples/collections/package.json
+++ b/max/soundworks/examples/collections/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@ircam/sc-components": "^3.0.0-alpha.44",
-    "@soundworks/core": "^4.0.0-alpha.0",
-    "@soundworks/helpers": "^1.0.0-alpha.2",
+    "@soundworks/core": "^4.0.0-alpha.20",
+    "@soundworks/helpers": "^1.0.0-alpha.11",
     "@soundworks/plugin-platform-init": "^1.0.0-alpha.5",
     "json5": "^2.2.2",
     "lit": "^3.0.2"

--- a/max/soundworks/examples/simple-server/package.json
+++ b/max/soundworks/examples/simple-server/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "@ircam/sc-components": "^3.0.0-alpha.44",
-    "@soundworks/core": "^4.0.0-alpha.0",
-    "@soundworks/helpers": "^1.0.0-alpha.2",
+    "@soundworks/core": "^4.0.0-alpha.20",
+    "@soundworks/helpers": "^1.0.0-alpha.11",
     "json5": "^2.2.2",
     "lit": "^3.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "src/max-server.js",
   "exports": {
-    ".": "src/max-server.js"
+    ".": "./src/max-server.js"
   },
   "scripts": {
     "build": "esbuild ./src/max-client.js  --bundle --format=cjs --platform=node --external:max-api --outfile=max/soundworks/javascript/soundworks.shared-state.cjs",
@@ -28,8 +27,6 @@
     "chai": "^5.1.0",
     "esbuild": "^0.20.2",
     "find-process": "^1.4.7",
-    "mocha": "^10.2.0",
-    "node-osc": "^9.1.1",
-    "open": "^10.1.0"
+    "mocha": "^10.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,27 +1,35 @@
 {
-  "name": "soundworks-max",
+  "name": "@soundworks/max",
   "version": "1.0.0",
   "description": "A Max client for sharing states with soundworks@v4",
+  "author": [
+    "Etienne Démoulin",
+    "Benjamin Matuszewski"
+  ],
+  "type": "module",
+  "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "src/max-server.js",
   "exports": {
     ".": "src/max-server.js"
   },
-  "type": "module",
   "scripts": {
     "build": "esbuild ./src/max-client.js  --bundle --format=cjs --platform=node --external:max-api --outfile=max/soundworks/javascript/soundworks.shared-state.cjs",
     "test": "npm run build && mocha",
     "launch-test-server": "VERBOSE=1 MODE=\"debug\" node ./tests/utils/create-soundworks-server.js",
     "preversion": "npm run build"
   },
-  "author": "",
-  "license": "ISC",
   "devDependencies": {
-    "@ircam/sc-utils": "^1.3.2",
-    "@soundworks/core": "^4.0.0-alpha.16",
-    "@soundworks/helpers": "^1.0.0-alpha.7",
-    "chai": "^4.3.10",
-    "esbuild": "^0.19.9",
+    "@ircam/sc-utils": "^1.3.3",
+    "@soundworks/core": "^4.0.0-alpha.20",
+    "@soundworks/helpers": "^1.0.0-alpha.11",
+    "chai": "^5.1.0",
+    "esbuild": "^0.20.2",
     "find-process": "^1.4.7",
-    "mocha": "^10.2.0"
+    "mocha": "^10.2.0",
+    "node-osc": "^9.1.1",
+    "open": "^10.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build": "esbuild ./src/max-client.js  --bundle --format=cjs --platform=node --external:max-api --outfile=max/soundworks/javascript/soundworks.shared-state.cjs",
     "test": "npm run build && mocha",
     "launch-test-server": "VERBOSE=1 MODE=\"debug\" node ./tests/utils/create-soundworks-server.js",
-    "preversion": "npm run build"
+    "preversion": "npm run toc && npm run build",
+    "toc": "markdown-toc -i README.md"
   },
   "devDependencies": {
     "@ircam/sc-utils": "^1.3.3",

--- a/tests/01_infrastructure/index.spec.js
+++ b/tests/01_infrastructure/index.spec.js
@@ -2,7 +2,7 @@ import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
 import { execSync } from 'node:child_process';
- import * as url from 'node:url';
+import * as url from 'node:url';
 
 import findProcess from 'find-process';
 import { assert } from 'chai';


### PR DESCRIPTION
This is required due to a breaking change in soundworks, so that newer version would not work with the package

I also changed the package name so that it is now `@soundworks/max` rather than `soundworks-max` to be consistent with other `soundworks` related packages

@etiennedemoulin if you have any app using this, after release, this implies that
- update `@soundworks/core` version
- change `soundworks-max` dependency to `@soundworks/max`

Ok for you?

